### PR TITLE
made Grid no_std compatible + removed stray logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,13 @@ status = "actively-developed"
 criterion = "0.3.1"
 rand="0.7.3"
 
+[dependencies]
+no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
+
 [[bench]]
 name = "benches"
 harness = false
+
+[features]
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,14 @@ grid.push_row(vec![7,8,9]);
 assert_eq!(grid, grid![[1,2,3][4,5,6][7,8,9]])
  ```
 */
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate no_std_compat as std;
+#[cfg(not(feature = "std"))]
+use std::prelude::v1::*;
+
 use std::cmp::Eq;
 use std::fmt;
 use std::iter::StepBy;
@@ -539,7 +547,6 @@ impl<T: Clone> Grid<T> {
             let mut col = Vec::with_capacity(self.rows);
             for i in 0..self.rows {
                 let idx = i * self.cols + self.cols - 1 - i;
-                println!["{:?}", idx];
                 col.push(self.data.remove(idx));
             }
             self.cols -= 1;


### PR DESCRIPTION
This does not change behavior for those who don't need no_std compatibility. 
If you declare the Grid-dependency like this after merge: 
```toml
grid = { version = "0.4.0", default-features = false }
```
You can use it on embedded devices assuming you have a memory allocator.

Both `cargo test --no-default-features` and `cargo test` still pass all tests.