### PR TITLE
Alternate Debug Formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,8 +772,16 @@ impl<T: fmt::Debug> fmt::Debug for Grid<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[");
         if self.cols > 0 {
-            for (i, _) in self.data.iter().enumerate().step_by(self.cols) {
-                write!(f, "{:?}", &self.data[i..(i + self.cols)]);
+            if f.alternate() {
+                write!(f, "\n");
+                for (i, _) in self.data.iter().enumerate().step_by(self.cols) {
+                    write!(f, "    {:?}", &self.data[i..(i + self.cols)]);
+                    write!(f, "\n");
+                }
+            } else {
+                for (i, _) in self.data.iter().enumerate().step_by(self.cols) {
+                    write!(f, "{:?}", &self.data[i..(i + self.cols)]);
+                }
             }
         }
         write!(f, "]")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,13 +773,12 @@ impl<T: fmt::Debug> fmt::Debug for Grid<T> {
         write!(f, "[");
         if self.cols > 0 {
             if f.alternate() {
-                let max_length = self.data.iter().map(|i| format!("{:?}", i).len()).max().unwrap();
                 write!(f, "\n");
                 for (i, _) in self.data.iter().enumerate().step_by(self.cols) {
-                    let mut row = self.data[i..(i + self.cols)].into_iter().peekable();
+                    let mut row = self.data[i..(i + self.cols)].iter().peekable();
                     write!(f, "    [");
                     while let Some(item) = row.next() {
-                        write!(f, " {item:padding$?}", padding = max_length);
+                        write!(f, " {item:width$.precision$?}", width = f.width().unwrap_or_default(), precision = f.precision().unwrap_or(2));
                         if row.peek().is_some() {
                             write!(f, ",");
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,10 +773,18 @@ impl<T: fmt::Debug> fmt::Debug for Grid<T> {
         write!(f, "[");
         if self.cols > 0 {
             if f.alternate() {
+                let max_length = self.data.iter().map(|i| format!("{:?}", i).len()).max().unwrap();
                 write!(f, "\n");
                 for (i, _) in self.data.iter().enumerate().step_by(self.cols) {
-                    write!(f, "    {:?}", &self.data[i..(i + self.cols)]);
-                    write!(f, "\n");
+                    let mut row = self.data[i..(i + self.cols)].into_iter().peekable();
+                    write!(f, "    [");
+                    while let Some(item) = row.next() {
+                        write!(f, " {item:padding$?}", padding = max_length);
+                        if row.peek().is_some() {
+                            write!(f, ",");
+                        }
+                    }
+                    write!(f, "]\n");
                 }
             } else {
                 for (i, _) in self.data.iter().enumerate().step_by(self.cols) {


### PR DESCRIPTION
Improve development experience by extending `alternate()` formatting options to the `grid` struct.

This includes:
1. new line formatting
2. width parameter
3. precision parameter

Tests included.

Using the `alternate()` flag in a predictable way helps achieve 👇

> Most of the functions std::Vec<T> offer are also implemented in grid and slightly modified for a 2D data object.

#### note:
In my testing I found that `str` and `String` don't respect the width/padding features of `format!()`. 

This results in most grids of strings (or compound types containing them) being doomed to look uneven.

If anyone knows how to address that I'd love to learn 😄

# criticism welcome