### PR TITLE
flip cols/rows in `out of range` panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ impl<T> Grid<T> {
             panic!("Inserted row must be of length {}, but was {}.", self.cols, row.len());
         }
         if index > self.rows {
-            panic!("Out of range. Index was {}, but must be less or equal to {}.", index, self.cols);
+            panic!("Out of range. Index was {}, but must be less or equal to {}.", index, self.rows);
         }
         self.rows += 1;
         let data_idx = index * self.cols;
@@ -646,7 +646,7 @@ impl<T> Grid<T> {
             panic!("Inserted col must be of length {}, but was {}.", self.rows, col.len());
         }
         if index > self.cols {
-            panic!("Out of range. Index was {}, but must be less or equal to {}.", index, self.rows);
+            panic!("Out of range. Index was {}, but must be less or equal to {}.", index, self.cols);
         }
         for (row_iter, col_val) in col.into_iter().enumerate() {
             let data_idx = row_iter * self.cols + index + row_iter;


### PR DESCRIPTION
### `insert_row` & `insert_col` returning inaccurate error messages. 

I believe flipping the size references fixes the issue. If not please let me know 😄 

## Example
```
use grid::*;

fn main() {
    let mut grid = grid![
        [1,2,3]
        [4,5,6]
    ];

    // thread 'main' panicked at 'Out of range. Index was 3, but must be less or equal to 3.'
    //                                                                                    ^ should say 2
    grid.insert_row(3, vec![7,8,9]);

    // thread 'main' panicked at 'Out of range. Index was 4, but must be less or equal to 2.'
    //                                                                                    ^ should say 3
    grid.insert_col(4, vec![11, 11])
}
```

# Criticism Welcome 