### PR TITLE
Remove "no-std-compat" dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,3 +25,11 @@ jobs:
       run: cargo test --verbose
     - name: Run test release
       run: cargo test --verbose --release
+  test-alloc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run test
+      run: cargo test --verbose --no-default-features
+    - name: Run test release
+      run: cargo test --verbose --release --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,10 @@ status = "actively-developed"
 criterion = "0.3.6"
 rand="0.8.5"
 
-[dependencies]
-no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
-
 [[bench]]
 name = "benches"
 harness = false
 
 [features]
 default = [ "std" ] # Default to using the std
-std = [ "no-std-compat/std" ]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,18 +33,18 @@ assert_eq!(grid, grid![[1,2,3][4,5,6][7,8,9]])
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
-extern crate no_std_compat as std;
-#[cfg(not(feature = "std"))]
-use std::prelude::v1::*;
+#[cfg(all(not(feature = "std")))]
+extern crate alloc;
+#[cfg(all(not(feature = "std")))]
+use alloc::{vec::Vec, vec, format};
 
-use std::cmp::Eq;
-use std::fmt;
-use std::iter::StepBy;
-use std::ops::Index;
-use std::ops::IndexMut;
-use std::slice::Iter;
-use std::slice::IterMut;
+use core::cmp::Eq;
+use core::fmt;
+use core::iter::StepBy;
+use core::ops::Index;
+use core::ops::IndexMut;
+use core::slice::Iter;
+use core::slice::IterMut;
 
 #[doc(hidden)]
 #[macro_export]
@@ -826,6 +826,8 @@ impl<T: Eq> Eq for Grid<T> {}
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(all(not(feature = "std")))]
+    use alloc::{string::String};
 
     #[test]
     #[should_panic]


### PR DESCRIPTION
It's easy to just import the types from the `core` and `alloc` libraries directly. No need for the dependency.

This PR:
- Make that changes and removes the `no_std_compat` dependency
- Adds configuration to run tests with the no_std (well, alloc) config in CI