### PR TITLE
Improve `get` and `get_mut` method signature, Add From implementations for Vec<Vec<T>> and (Vec<T>, usize)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.12.0"
 authors = ["Armin Becher <armin.becher@gmai.com>"]
 edition = "2018"
 description = "Dynamic generic 2D data structure."
-keywords = [ "2D", "array", "matrix", "data-structure", "2D-vector"]
-categories = [ "science", "data-structures",]
+keywords = ["2D", "array", "matrix", "data-structure", "2D-vector"]
+categories = ["science", "data-structures"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/becheran/grid"
@@ -23,7 +23,7 @@ serde = { version = "1.0.188", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.6"
-rand="0.8.5"
+rand = "0.8.5"
 serde_json = "1.0.106"
 
 [[bench]]
@@ -31,6 +31,6 @@ name = "benches"
 harness = false
 
 [features]
-default = [ "std" ] # Default to using the std
+default = ["std"]            # Default to using the std
 std = []
-serde = [ "std", "dep:serde" ]
+serde = ["std", "dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,8 +495,8 @@ impl<T> Grid<T> {
     /// Calling this method with an out-of-bounds index is undefined behavior even if the resulting reference is not used.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked(&self, row: usize, col: usize) -> &T {
-        let index = self.get_index(row, col);
+    pub unsafe fn get_unchecked<U: Into<usize>>(&self, row: U, col: U) -> &T {
+        let index = self.get_index(row.into(), col.into());
         self.data.get_unchecked(index)
     }
 
@@ -508,8 +508,8 @@ impl<T> Grid<T> {
     /// Calling this method with an out-of-bounds index is undefined behavior even if the resulting reference is not used.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked_mut(&mut self, row: usize, col: usize) -> &mut T {
-        let index = self.get_index(row, col);
+    pub unsafe fn get_unchecked_mut<U: Into<usize>>(&mut self, row: U, col: U) -> &mut T {
+        let index = self.get_index(row.into(), col.into());
         self.data.get_unchecked_mut(index)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,11 @@ impl<T> Grid<T> {
     /// Calling this method with an out-of-bounds index is undefined behavior even if the resulting reference is not used.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked_mut(&mut self, row: impl Into<usize>, col: impl Into<usize>) -> &mut T {
+    pub unsafe fn get_unchecked_mut(
+        &mut self,
+        row: impl Into<usize>,
+        col: impl Into<usize>,
+    ) -> &mut T {
         let index = self.get_index(row.into(), col.into());
         self.data.get_unchecked_mut(index)
     }
@@ -530,7 +534,11 @@ impl<T> Grid<T> {
     /// Mutable access to a certain element in the grid.
     /// Returns `None` if an element beyond the grid bounds is tried to be accessed.
     #[must_use]
-    pub fn get_mut(&mut self, row: impl TryInto<usize>, col: impl TryInto<usize>) -> Option<&mut T> {
+    pub fn get_mut(
+        &mut self,
+        row: impl TryInto<usize>,
+        col: impl TryInto<usize>,
+    ) -> Option<&mut T> {
         let row_usize = row.try_into().ok()?;
         let col_usize = col.try_into().ok()?;
         if row_usize < self.rows && col_usize < self.cols {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,12 +1592,14 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn from_vec_panics_1() {
         let _: Grid<u8> = Grid::from_vec(vec![1, 2, 3], 0);
     }
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn from_vec_panics_2() {
         let _: Grid<u8> = Grid::from_vec(vec![1, 2, 3], 2);
     }
@@ -1624,12 +1626,14 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn from_vec_with_order_panics_1() {
         let _: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3], 0, Order::ColumnMajor);
     }
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn from_vec_with_order_panics_2() {
         let _: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3], 2, Order::ColumnMajor);
     }
@@ -1651,6 +1655,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_col_out_of_idx() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3, 4], 2, Order::RowMajor);
         grid.insert_col(3, vec![4, 5]);
@@ -1672,6 +1677,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_col_out_of_idx_column_major() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 3, 2, 4], 2, Order::ColumnMajor);
         grid.insert_col(3, vec![4, 5]);
@@ -1700,6 +1706,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_row_out_of_idx() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3, 4], 2, Order::RowMajor);
         grid.insert_row(3, vec![4, 5]);
@@ -1707,6 +1714,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_row_wrong_size_of_idx() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3, 4], 2, Order::RowMajor);
         grid.insert_row(1, vec![4, 5, 4]);
@@ -1735,6 +1743,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_row_out_of_idx_column_major() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3, 4], 2, Order::ColumnMajor);
         grid.insert_row(3, vec![4, 5]);
@@ -1742,6 +1751,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn insert_row_wrong_size_of_idx_column_major() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![1, 2, 3, 4], 2, Order::ColumnMajor);
         grid.insert_row(1, vec![4, 5, 4]);
@@ -1950,6 +1960,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn idx_tup_out_of_col_bounds() {
         let grid: Grid<char> = grid![['a', 'b', 'c', 'd']['a', 'b', 'c', 'd']['a', 'b', 'c', 'd']];
         let _ = grid[(0, 5)];
@@ -1993,6 +2004,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_col_wrong_size() {
         let mut grid: Grid<char> = grid![['a','a','a']['a','a','a']];
         grid.push_col(vec!['b']);
@@ -2001,6 +2013,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_col_zero_len() {
         let mut grid: Grid<char> = grid![];
         grid.push_col(vec![]);
@@ -2043,6 +2056,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_col_wrong_size_column_major() {
         let mut grid: Grid<char> = Grid::init_with_order(2, 3, Order::ColumnMajor, 'a');
         grid.push_col(vec!['b']);
@@ -2051,6 +2065,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_col_zero_len_column_major() {
         let mut grid: Grid<char> = Grid::new_with_order(0, 0, Order::ColumnMajor);
         grid.push_col(vec![]);
@@ -2072,6 +2087,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_empty_row() {
         let mut grid = Grid::init(0, 1, 0);
         grid.push_row(vec![]);
@@ -2079,6 +2095,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_row_wrong_size() {
         let mut grid: Grid<char> = grid![['a','a','a']['a','a','a']];
         grid.push_row(vec!['b']);
@@ -2101,6 +2118,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_empty_row_column_major() {
         let mut grid = Grid::init_with_order(0, 1, Order::ColumnMajor, 0);
         grid.push_row(vec![]);
@@ -2108,6 +2126,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn push_row_wrong_size_column_major() {
         let mut grid: Grid<char> =
             Grid::from_vec_with_order(vec!['a', 'a', 'a', 'a', 'a', 'a'], 3, Order::ColumnMajor);
@@ -2124,6 +2143,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_out_of_bound() {
         let grid = Grid::from_vec_with_order(vec![1, 2, 3, 4, 5, 6], 3, Order::RowMajor);
         let _ = grid.iter_row(3);
@@ -2131,6 +2151,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_zero() {
         let grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::RowMajor);
         let _ = grid.iter_row(0);
@@ -2145,6 +2166,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_rowumn_major_out_of_bound() {
         let grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
         let _ = grid.iter_row(3);
@@ -2152,6 +2174,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_rowumn_major_zero() {
         let grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::ColumnMajor);
         let _ = grid.iter_row(0);
@@ -2166,6 +2189,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_mut_out_of_bound() {
         let mut grid = Grid::from_vec_with_order(vec![1, 2, 3, 4, 5, 6], 3, Order::RowMajor);
         let _ = grid.iter_row_mut(3);
@@ -2173,6 +2197,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_mut_zero() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::RowMajor);
         let _ = grid.iter_row_mut(0);
@@ -2187,6 +2212,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_mut_rowumn_major_out_of_bound() {
         let mut grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
         let _ = grid.iter_row_mut(3);
@@ -2194,6 +2220,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_row_mut_rowumn_major_zero() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::ColumnMajor);
         let _ = grid.iter_row_mut(0);
@@ -2208,6 +2235,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_out_of_bound() {
         let grid = Grid::from_vec_with_order(vec![1, 2, 3, 4, 5, 6], 3, Order::RowMajor);
         let _ = grid.iter_col(3);
@@ -2215,6 +2243,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_zero() {
         let grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::RowMajor);
         let _ = grid.iter_col(0);
@@ -2229,6 +2258,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_column_major_out_of_bound() {
         let grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
         let _ = grid.iter_col(3);
@@ -2236,6 +2266,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_column_major_zero() {
         let grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::ColumnMajor);
         let _ = grid.iter_col(0);
@@ -2250,6 +2281,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_mut_out_of_bound() {
         let mut grid = Grid::from_vec_with_order(vec![1, 2, 3, 4, 5, 6], 3, Order::RowMajor);
         let _ = grid.iter_col_mut(3);
@@ -2257,6 +2289,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_mut_zero() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::RowMajor);
         let _ = grid.iter_col_mut(0);
@@ -2271,6 +2304,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_mut_column_major_out_of_bound() {
         let mut grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
         let _ = grid.iter_col_mut(3);
@@ -2278,6 +2312,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn iter_col_mut_column_major_zero() {
         let mut grid: Grid<u8> = Grid::from_vec_with_order(vec![], 0, Order::ColumnMajor);
         let _ = grid.iter_col_mut(0);
@@ -2365,31 +2400,31 @@ mod test {
     #[test]
     fn fmt_empty() {
         let grid: Grid<u8> = grid![];
-        assert_eq!(format!("{:?}", grid), "[]");
+        assert_eq!(format!("{grid:?}"), "[]");
     }
 
     #[test]
     fn fmt_row() {
         let grid: Grid<u8> = grid![[1, 2, 3]];
-        assert_eq!(format!("{:?}", grid), "[[1, 2, 3]]");
+        assert_eq!(format!("{grid:?}"), "[[1, 2, 3]]");
     }
 
     #[test]
     fn fmt_grid() {
         let grid: Grid<u8> = grid![[1,2,3][4,5,6][7,8,9]];
-        assert_eq!(format!("{:?}", grid), "[[1, 2, 3][4, 5, 6][7, 8, 9]]");
+        assert_eq!(format!("{grid:?}"), "[[1, 2, 3][4, 5, 6][7, 8, 9]]");
     }
 
     #[test]
     fn fmt_column_major() {
         let grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
-        assert_eq!(format!("{:?}", grid), "[[1, 2, 3][4, 5, 6]]");
+        assert_eq!(format!("{grid:?}"), "[[1, 2, 3][4, 5, 6]]");
     }
 
     #[test]
     fn fmt_pretty_empty() {
         let grid: Grid<f32> = grid![];
-        assert_eq!(format!("{:#?}", grid), "[]");
+        assert_eq!(format!("{grid:#?}"), "[]");
     }
 
     #[test]
@@ -2400,21 +2435,21 @@ mod test {
             [7,8,95]
         ];
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [  1,  2,  3]
     [  4,  5,  6]
     [  7,  8, 95]
-]"#;
+]";
 
-        assert_eq!(format!("{:#?}", grid), expected_output);
+        assert_eq!(format!("{grid:#?}"), expected_output);
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [   1,   2,   3]
     [   4,   5,   6]
     [   7,   8,  95]
-]"#;
+]";
 
-        assert_eq!(format!("{:#3?}", grid), expected_output);
+        assert_eq!(format!("{grid:#3?}"), expected_output);
     }
 
     #[test]
@@ -2425,21 +2460,21 @@ mod test {
             [7.1,8.23444,95.55]
         ];
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [   1.5,   2.6,   3.4]
     [   4.8,   5.0,   6.0]
     [   7.1,   8.2,  95.6]
-]"#;
+]";
 
-        assert_eq!(format!("{:#5.1?}", grid), expected_output);
+        assert_eq!(format!("{grid:#5.1?}"), expected_output);
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [  1.50000,  2.60000,  3.44000]
     [  4.77500,  5.00000,  6.00000]
     [  7.10000,  8.23444, 95.55000]
-]"#;
+]";
 
-        assert_eq!(format!("{:#8.5?}", grid), expected_output);
+        assert_eq!(format!("{grid:#8.5?}"), expected_output);
     }
 
     #[test]
@@ -2449,19 +2484,19 @@ mod test {
             [(80, 90), (5, 6)]
         ];
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [ (        5,        66), (      432,        55)]
     [ (       80,        90), (        5,         6)]
-]"#;
+]";
 
         assert_eq!(format!("{grid:#?}"), expected_output);
 
-        let expected_output = r#"[
+        let expected_output = r"[
     [ (  5,  66), (432,  55)]
     [ ( 80,  90), (  5,   6)]
-]"#;
+]";
 
-        assert_eq!(format!("{:#3?}", grid), expected_output);
+        assert_eq!(format!("{grid:#3?}"), expected_output);
     }
 
     #[test]
@@ -2491,17 +2526,17 @@ mod test {
     [ Person { _name: "Sam", _precise_age: 8.99950 }, Person { _name: "John Doe", _precise_age: 40.14000 }]
 ]"#;
 
-        assert_eq!(format!("{:#5.5?}", grid), expected_output);
+        assert_eq!(format!("{grid:#5.5?}"), expected_output);
     }
 
     #[test]
     fn fmt_pretty_column_major() {
         let grid = Grid::from_vec_with_order(vec![1, 4, 2, 5, 3, 6], 3, Order::ColumnMajor);
-        let expected_output = r#"[
+        let expected_output = r"[
     [ 1, 2, 3]
     [ 4, 5, 6]
-]"#;
-        assert_eq!(format!("{:#?}", grid), expected_output);
+]";
+        assert_eq!(format!("{grid:#?}"), expected_output);
     }
 
     #[test]
@@ -2583,6 +2618,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn init_panics() {
         Grid::init(usize::MAX, 2, 3);
     }
@@ -2610,6 +2646,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn init_with_order_panics() {
         Grid::init_with_order(usize::MAX, 2, Order::ColumnMajor, 3);
     }
@@ -2631,6 +2668,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn new_panics() {
         let _: Grid<u8> = Grid::new(usize::MAX, 2);
     }
@@ -2652,6 +2690,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn new_with_order_panics() {
         let _: Grid<u8> = Grid::new_with_order(usize::MAX, 2, Order::ColumnMajor);
     }
@@ -2724,6 +2763,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn idx_tup_panic_1() {
         let grid = Grid::init(1, 2, 3);
         let _ = grid[(20, 0)];
@@ -2731,6 +2771,7 @@ mod test {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn idx_tup_panic_2() {
         let grid = Grid::init(1, 2, 3);
         let _ = grid[(0, 20)];
@@ -2771,6 +2812,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn iter_rows() {
         let grid: Grid<u8> = grid![[1,2,3][4,5,6]];
         let max_by_row: Vec<u8> = grid
@@ -2785,6 +2827,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn iter_cols() {
         let grid: Grid<u8> = grid![[1,2,3][4,5,6]];
         let max_by_col: Vec<u8> = grid
@@ -2795,7 +2838,7 @@ mod test {
 
         assert_eq!(max_by_col, vec![4, 5, 6]);
 
-        let sum_by_col: Vec<u8> = grid.iter_cols().map(|col| col.sum()).collect();
+        let sum_by_col: Vec<u8> = grid.iter_cols().map(|row| row.sum()).collect();
         assert_eq!(sum_by_col, vec![1 + 4, 2 + 5, 3 + 6]);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ use serde::{
     ser::{Serialize, SerializeStruct, Serializer},
 };
 
-use core::cmp;
 use core::cmp::Eq;
 use core::fmt;
 use core::iter::StepBy;
@@ -60,6 +59,7 @@ use core::ops::Index;
 use core::ops::IndexMut;
 use core::slice::Iter;
 use core::slice::IterMut;
+use core::{cmp, convert::TryInto};
 
 #[doc(hidden)]
 #[macro_export]
@@ -516,9 +516,11 @@ impl<T> Grid<T> {
     /// Access a certain element in the grid.
     /// Returns `None` if an element beyond the grid bounds is tried to be accessed.
     #[must_use]
-    pub fn get(&self, row: usize, col: usize) -> Option<&T> {
-        if row < self.rows && col < self.cols {
-            unsafe { Some(self.get_unchecked(row, col)) }
+    pub fn get<U: TryInto<usize>>(&self, row: U, col: U) -> Option<&T> {
+        let row_usize = row.try_into().ok()?;
+        let col_usize = col.try_into().ok()?;
+        if row_usize < self.rows && col_usize < self.cols {
+            unsafe { Some(self.get_unchecked(row_usize, col_usize)) }
         } else {
             None
         }
@@ -527,9 +529,11 @@ impl<T> Grid<T> {
     /// Mutable access to a certain element in the grid.
     /// Returns `None` if an element beyond the grid bounds is tried to be accessed.
     #[must_use]
-    pub fn get_mut(&mut self, row: usize, col: usize) -> Option<&mut T> {
-        if row < self.rows && col < self.cols {
-            unsafe { Some(self.get_unchecked_mut(row, col)) }
+    pub fn get_mut<U: TryInto<usize>>(&mut self, row: U, col: U) -> Option<&mut T> {
+        let row_usize = row.try_into().ok()?;
+        let col_usize = col.try_into().ok()?;
+        if row_usize < self.rows && col_usize < self.cols {
+            unsafe { Some(self.get_unchecked_mut(row_usize, col_usize)) }
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ impl<T> Grid<T> {
     /// Calling this method with an out-of-bounds index is undefined behavior even if the resulting reference is not used.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked<U: Into<usize>>(&self, row: U, col: U) -> &T {
+    pub unsafe fn get_unchecked(&self, row: impl Into<usize>, col: impl Into<usize>) -> &T {
         let index = self.get_index(row.into(), col.into());
         self.data.get_unchecked(index)
     }
@@ -509,7 +509,7 @@ impl<T> Grid<T> {
     /// Calling this method with an out-of-bounds index is undefined behavior even if the resulting reference is not used.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked_mut<U: Into<usize>>(&mut self, row: U, col: U) -> &mut T {
+    pub unsafe fn get_unchecked_mut(&mut self, row: impl Into<usize>, col: impl Into<usize>) -> &mut T {
         let index = self.get_index(row.into(), col.into());
         self.data.get_unchecked_mut(index)
     }
@@ -517,7 +517,7 @@ impl<T> Grid<T> {
     /// Access a certain element in the grid.
     /// Returns `None` if an element beyond the grid bounds is tried to be accessed.
     #[must_use]
-    pub fn get<U: TryInto<usize>>(&self, row: U, col: U) -> Option<&T> {
+    pub fn get(&self, row: impl TryInto<usize>, col: impl TryInto<usize>) -> Option<&T> {
         let row_usize = row.try_into().ok()?;
         let col_usize = col.try_into().ok()?;
         if row_usize < self.rows && col_usize < self.cols {
@@ -530,7 +530,7 @@ impl<T> Grid<T> {
     /// Mutable access to a certain element in the grid.
     /// Returns `None` if an element beyond the grid bounds is tried to be accessed.
     #[must_use]
-    pub fn get_mut<U: TryInto<usize>>(&mut self, row: U, col: U) -> Option<&mut T> {
+    pub fn get_mut(&mut self, row: impl TryInto<usize>, col: impl TryInto<usize>) -> Option<&mut T> {
         let row_usize = row.try_into().ok()?;
         let col_usize = col.try_into().ok()?;
         if row_usize < self.rows && col_usize < self.cols {
@@ -2877,7 +2877,7 @@ mod test {
     #[test]
     fn get() {
         let grid = Grid::from_vec_with_order(vec![1, 2], 2, Order::RowMajor);
-        assert_eq!(grid.get(0, 1), Some(&2));
+        assert_eq!(grid.get(0_i64, 1_i32), Some(&2));
     }
 
     #[test]
@@ -2901,7 +2901,7 @@ mod test {
     #[test]
     fn get_mut() {
         let mut grid = Grid::from_vec_with_order(vec![1, 2], 2, Order::RowMajor);
-        assert_eq!(grid.get_mut(0, 1), Some(&mut 2));
+        assert_eq!(grid.get_mut(0_i64, 1_i32), Some(&mut 2));
     }
 
     #[test]


### PR DESCRIPTION
While using this library, I found it difficult to get neighbors because of the possibility of overflows when going negative. For instance, to get the neighbor that is up and to the left of the current cell, I would have to something like this:

```rust
let row: usize = 0;
let col: usize = 0;
if let Some(row) = row.checked_sub(1) {
    if let Some(col) = col.checked_sub(1) {
        if let Some(cell) = grid.get(row, col) {
            dbg!(cell);
        }
    }
}
```

This was a lot of code. Ideally, I could just do this:

```rust
let row: isize = 0;
let col: isize = 0;
if let Some(cell) = grid.get(row - 1, col - 1) {
    dbg!(cell);
}
```

Unfortunately, `.get` and `.get_mut` do not accept anything but `usize`, so this would cause an overflow warning.

I started adding this to my rust projects:

```rust
trait GetChecked<T> {
    fn get_checked(&self, row: isize, col: isize) -> Option<&T>;
    fn get_checked_mut(&mut self, row: isize, col: isize) -> Option<&mut T>;
}

impl<T> GetChecked<T> for Grid<T> {
    fn get_checked(&self, row: isize, col: isize) -> Option<&T> {
        self.get(row.try_into().ok()?, col.try_into().ok()?)
    }

    fn get_checked_mut(&mut self, row: isize, col: isize) -> Option<&mut T> {
        self.get_mut(row.try_into().ok()?, col.try_into().ok()?)
    }
}
```

This trait and implementation allowed me to add new methods called `get_checked` and `get_checked_mut` to do what I wanted: pass in an isize or any other thing that could be converted into a number. If it was less than 0, it would return None, which is perfect: there wouldn't be a value there anyway!

```rust
let row: isize = 1;
let col: isize = 1;
if let Some(cell) = grid.get_checked(row - 1, col - 1) {
    dbg!(cell);
}
```

After implementing this a couple times, I figured that it was useful enough to contribute to this library, hence this PR. (I also cleaned up some of the clippy linter warnings I was getting! And added implentation for From which makes more sense than adding a `from_vec` method, making it possible to potentially remove that function one day)