### PR TITLE
Add ExactSize and DoubleEnded impls to GridRow and Col Iter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1648,14 +1648,14 @@ impl<T: Clone> From<(&Vec<T>, &usize)> for Grid<T> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GridRowIter<'a, T> {
     grid: &'a Grid<T>,
     row_start_index: usize,
     row_end_index: usize,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GridColIter<'a, T> {
     grid: &'a Grid<T>,
     col_start_index: usize,
@@ -3134,7 +3134,6 @@ mod test {
     #[allow(clippy::redundant_closure_for_method_calls)]
     fn iter_rows() {
         let grid: Grid<u8> = grid![[1,2,3][4,5,6]];
-        print!("grid: {grid:?}");
         let max_by_row: Vec<u8> = grid
             .iter_rows()
             .map(|row| row.max().unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -835,7 +835,7 @@ impl<T> Grid<T> {
     ///     *i += 1;
     ///     println!("value at row {row} and column {col} is: {i}");
     /// }
-    /// 
+    ///
     /// assert_eq!(grid[(0, 0)], 2);
     /// assert_eq!(grid[(0, 1)], 3);
     /// assert_eq!(grid[(1, 0)], 4);
@@ -1681,7 +1681,7 @@ impl<'a, T> Iterator for GridRowIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for GridRowIter<'a, T> { }
+impl<'a, T> ExactSizeIterator for GridRowIter<'a, T> {}
 
 impl<'a, T> DoubleEndedIterator for GridRowIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -1714,7 +1714,7 @@ impl<'a, T> Iterator for GridColIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for GridColIter<'a, T> { }
+impl<'a, T> ExactSizeIterator for GridColIter<'a, T> {}
 
 impl<'a, T> DoubleEndedIterator for GridColIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
I wrote implementations of ExactSizeIterator and DoubleEndedIterator for GridRowIter and GridColIter.
 - adds one usize of additional memory usage to both types
 - makes both more versatile and maybe even faster (e.g. when collecting into a vec ExactSizeIterator should reduce the needed allocations)
 
The changes to Iterator are bigger than actually needed, but now the next and next_back functions look very similar.
Iterator still passes all test. I also added tests for all new code.

Maybe closes https://github.com/becheran/grid/issues/38, which i just notices while writing this.