### PR TITLE
chore: address some clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,7 @@ impl<T> Grid<T> {
     /// # Panics
     ///
     /// Panics if `rows * cols > usize::MAX` or if `rows * cols * size_of::<T>() > isize::MAX`
+    #[must_use]
     pub fn with_capacity(rows: usize, cols: usize) -> Self {
         Self::with_capacity_and_order(rows, cols, Order::default())
     }
@@ -427,6 +428,7 @@ impl<T> Grid<T> {
     /// # Panics
     ///
     /// Panics if `rows * cols > usize::MAX` or if `rows * cols * size_of::<T>() > isize::MAX`
+    #[must_use]
     pub fn with_capacity_and_order(rows: usize, cols: usize, order: Order) -> Self {
         Self {
             data: Vec::with_capacity(rows.checked_mul(cols).unwrap()),
@@ -634,6 +636,7 @@ impl<T> Grid<T> {
     /// assert_eq!(iter.next(), Some(&4));
     /// assert_eq!(iter.next(), None);
     /// ```
+    #[allow(clippy::iter_without_into_iter)]
     pub fn iter(&self) -> Iter<T> {
         self.data.iter()
     }
@@ -650,6 +653,7 @@ impl<T> Grid<T> {
     /// assert_eq!(next, Some(&mut 1));
     /// *next.unwrap() = 10;
     /// ```
+    #[allow(clippy::iter_without_into_iter)]
     pub fn iter_mut(&mut self) -> IterMut<T> {
         self.data.iter_mut()
     }
@@ -1731,9 +1735,9 @@ impl<'a, T> Iterator for GridRowIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for GridRowIter<'a, T> {}
+impl<T> ExactSizeIterator for GridRowIter<'_, T> {}
 
-impl<'a, T> DoubleEndedIterator for GridRowIter<'a, T> {
+impl<T> DoubleEndedIterator for GridRowIter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.row_start_index >= self.row_end_index {
             return None;
@@ -1764,9 +1768,9 @@ impl<'a, T> Iterator for GridColIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for GridColIter<'a, T> {}
+impl<T> ExactSizeIterator for GridColIter<'_, T> {}
 
-impl<'a, T> DoubleEndedIterator for GridColIter<'a, T> {
+impl<T> DoubleEndedIterator for GridColIter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.col_start_index >= self.col_end_index {
             return None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 /*!
 # Two Dimensional Grid
 Continuous growable 2D data structure.
@@ -197,7 +197,7 @@ pub enum Order {
 }
 
 impl Order {
-    fn counterpart(self) -> Self {
+    const fn counterpart(self) -> Self {
         match self {
             Self::RowMajor => Self::ColumnMajor,
             Self::ColumnMajor => Self::RowMajor,
@@ -488,14 +488,14 @@ impl<T> Grid<T> {
             cols
         );
         if rows == 0 || cols == 0 {
-            Grid {
+            Self {
                 data: vec,
                 rows: 0,
                 cols: 0,
                 order,
             }
         } else {
-            Grid {
+            Self {
                 data: vec,
                 rows,
                 cols,
@@ -507,7 +507,7 @@ impl<T> Grid<T> {
     /// Returns the index of the coordinates in the internal vector.
     #[inline]
     #[must_use]
-    fn get_index(&self, row: usize, col: usize) -> usize {
+    const fn get_index(&self, row: usize, col: usize) -> usize {
         match self.order {
             Order::RowMajor => row * self.cols + col,
             Order::ColumnMajor => col * self.rows + row,
@@ -577,25 +577,25 @@ impl<T> Grid<T> {
     /// Returns the size of the grid as a two element tuple.
     /// First element are the number of rows and the second the columns.
     #[must_use]
-    pub fn size(&self) -> (usize, usize) {
+    pub const fn size(&self) -> (usize, usize) {
         (self.rows, self.cols)
     }
 
     /// Returns the number of rows of the grid.
     #[must_use]
-    pub fn rows(&self) -> usize {
+    pub const fn rows(&self) -> usize {
         self.rows
     }
 
     /// Returns the number of columns of the grid.
     #[must_use]
-    pub fn cols(&self) -> usize {
+    pub const fn cols(&self) -> usize {
         self.cols
     }
 
     /// Returns the internal memory layout of the grid.
     #[must_use]
-    pub fn order(&self) -> Order {
+    pub const fn order(&self) -> Order {
         self.order
     }
 
@@ -1259,7 +1259,7 @@ impl<T> Grid<T> {
     /// assert_eq!(flat, &vec![1,2,3,4,5,6]);
     /// ```
     #[must_use]
-    pub fn flatten(&self) -> &Vec<T> {
+    pub const fn flatten(&self) -> &Vec<T> {
         &self.data
     }
 
@@ -1469,7 +1469,7 @@ impl<T> Grid<T> {
     /// assert_eq!(sum_by_row, vec![1+2+3, 4+5+6])
     /// ```
     #[must_use]
-    pub fn iter_rows(&self) -> GridRowIter<'_, T> {
+    pub const fn iter_rows(&self) -> GridRowIter<'_, T> {
         GridRowIter {
             grid: self,
             row_start_index: 0,
@@ -1492,7 +1492,7 @@ impl<T> Grid<T> {
     /// assert_eq!(sum_by_col, vec![1+4, 2+5, 3+6])
     /// ```
     #[must_use]
-    pub fn iter_cols(&self) -> GridColIter<'_, T> {
+    pub const fn iter_cols(&self) -> GridColIter<'_, T> {
         GridColIter {
             grid: self,
             col_start_index: 0,
@@ -1540,7 +1540,7 @@ impl<T> Default for Grid<T> {
 
 impl<T: Clone> Clone for Grid<T> {
     fn clone(&self) -> Self {
-        Grid {
+        Self {
             rows: self.rows,
             cols: self.cols,
             data: self.data.clone(),


### PR DESCRIPTION
Some things clippy warns about in 1.83.

The second commit adds the nursery checks too, which seemed useful, but I could drop it if preferred.