### PR TITLE
chore: add min version of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/becheran/grid"
 documentation = "https://docs.rs/grid"
+rust-version = "1.51"
 
 [badges.gitlab]
 repository = "becheran/grid_ci"


### PR DESCRIPTION
This value was based on the use of `fill_with` (Rust tells you this if you try to set it).

