### PR TITLE
feat: add expand_rows and expand_cols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1582,7 +1582,7 @@ impl<T> Grid<T> {
 impl<T: Default> Grid<T> {
     /// Expands the grid with the given amount of rows filling the new rows with T::default().
     /// If the grid has no rows or no columns, nothing will happen.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -1603,12 +1603,8 @@ impl<T: Default> Grid<T> {
     /// This method will be significantly slower if the grid uses a column-major memory layout.
     pub fn expand_rows(&mut self, rows: usize) {
         if rows > 0 && self.cols > 0 {
-            let mut new_rows = Vec::with_capacity(rows * self.cols);
-            for _ in 0..new_rows.capacity() {
-                new_rows.push(T::default());
-            }
-
-            self.data.extend(new_rows);
+            self.data
+                .resize_with(self.data.len() + rows * self.cols, T::default);
 
             if self.order == Order::ColumnMajor {
                 for row_added in 0..rows {
@@ -1644,12 +1640,8 @@ impl<T: Default> Grid<T> {
     /// This method will be significantly slower if the grid uses a row-major memory layout.
     pub fn expand_cols(&mut self, cols: usize) {
         if cols > 0 && self.rows > 0 {
-            let mut new_cols = Vec::with_capacity(cols * self.rows);
-            for _ in 0..new_cols.capacity() {
-                new_cols.push(T::default());
-            }
-
-            self.data.extend(new_cols);
+            self.data
+                .resize_with(self.data.len() + cols * self.rows, T::default);
 
             if self.order == Order::RowMajor {
                 for col_added in 0..cols {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1580,7 +1580,7 @@ impl<T> Grid<T> {
 }
 
 impl<T: Default> Grid<T> {
-    /// Expands the grid with the given amount of rows filling the new rows with T::default().
+    /// Expands the grid with the given amount of rows filling the new rows with `T::default()`.
     /// If the grid has no rows or no columns, nothing will happen.
     ///
     /// # Examples
@@ -1619,7 +1619,7 @@ impl<T: Default> Grid<T> {
         }
     }
 
-    /// Expands the grid with the given amount of cols filling the new cols with T::default().
+    /// Expands the grid with the given amount of cols filling the new cols with `T::default()`.
     /// If the grid has no rows or no columns, nothing will happen.
     ///
     /// # Examples
@@ -2654,7 +2654,7 @@ mod test {
         assert_eq!(grid.order, Order::RowMajor);
         assert_eq!(grid.rows(), 0);
         assert_eq!(grid.cols(), 0);
-        assert_eq!(grid.into_vec(), vec![]);
+        assert_eq!(grid.into_vec(), Vec::<u8>::new());
     }
 
     #[test]
@@ -2702,7 +2702,7 @@ mod test {
         assert_eq!(grid.order, Order::RowMajor);
         assert_eq!(grid.rows(), 0);
         assert_eq!(grid.cols(), 0);
-        assert_eq!(grid.into_vec(), vec![]);
+        assert_eq!(grid.into_vec(), Vec::<u8>::new());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1579,6 +1579,50 @@ impl<T> Grid<T> {
     }
 }
 
+impl<T: Default> Grid<T> {
+    /// Expands the grid with the given amount of rows filling the new rows with T::default().
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grid::*;
+    /// let mut grid: Grid<u8> = grid![[1, 2, 3][3, 4, 5]];
+    /// grid.expand_rows(2);
+    /// assert_eq!(grid.rows(), 4);
+    /// assert_eq!(grid[(2, 0)], 0);
+    /// assert_eq!(grid[(2, 1)], 0);
+    /// assert_eq!(grid[(2, 2)], 0);
+    /// assert_eq!(grid[(3, 0)], 0);
+    /// assert_eq!(grid[(3, 1)], 0);
+    /// assert_eq!(grid[(3, 2)], 0);
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// This method will be significantly slower if the grid uses a column-major memory layout.
+    pub fn expand_rows(&mut self, rows: usize) {
+        if rows > 0 && self.cols > 0 {
+            let mut new_rows = Vec::with_capacity(rows * self.cols);
+            for _ in 0..new_rows.capacity() {
+                new_rows.push(T::default());
+            }
+
+            self.data.extend(new_rows);
+
+            if self.order == Order::ColumnMajor {
+                for row_added in 0..rows {
+                    for i in (1..self.cols).rev() {
+                        let total_rows = self.rows + row_added;
+                        let col_idx = i * total_rows;
+                        self.data[col_idx..col_idx + total_rows + i].rotate_right(i);
+                    }
+                }
+            }
+            self.rows += rows;
+        }
+    }
+}
+
 impl<T> Default for Grid<T> {
     fn default() -> Self {
         Self {
@@ -2529,6 +2573,54 @@ mod test {
             Grid::from_vec_with_order(vec!['a', 'a', 'a', 'a', 'a', 'a'], 3, Order::ColumnMajor);
         grid.push_row(vec!['b']);
         grid.push_row(vec!['b', 'b', 'b', 'b']);
+    }
+
+    #[test]
+    fn expand_rows() {
+        let mut grid = Grid::from_vec_with_order(vec![1, 1, 1, 2, 2, 2], 3, Order::RowMajor);
+        grid.expand_rows(2);
+
+        assert_eq!(grid.size(), (4, 3));
+        assert_eq!(grid.order, Order::RowMajor);
+        assert_eq!(grid.rows(), 4);
+        assert_eq!(grid.cols(), 3);
+        assert_eq!(grid.into_vec(), vec![1, 1, 1, 2, 2, 2, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn expand_rows_column_major() {
+        let mut grid = Grid::from_vec_with_order(vec![1, 2, 1, 2, 1, 2], 3, Order::ColumnMajor);
+        grid.expand_rows(2);
+
+        assert_eq!(grid.size(), (4, 3));
+        assert_eq!(grid.order, Order::ColumnMajor);
+        assert_eq!(grid.rows(), 4);
+        assert_eq!(grid.cols(), 3);
+        assert_eq!(grid.into_vec(), vec![1, 2, 0, 0, 1, 2, 0, 0, 1, 2, 0, 0]);
+    }
+
+    #[test]
+    fn expand_rows_zero() {
+        let mut grid = Grid::from_vec_with_order(vec![1, 1, 1], 3, Order::RowMajor);
+        grid.expand_rows(0);
+
+        assert_eq!(grid.size(), (1, 3));
+        assert_eq!(grid.order, Order::RowMajor);
+        assert_eq!(grid.rows(), 1);
+        assert_eq!(grid.cols(), 3);
+        assert_eq!(grid.into_vec(), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn expand_rows_empty_grid() {
+        let mut grid: Grid<u8> = Grid::init(0, 0, 0);
+        grid.expand_rows(2);
+
+        assert_eq!(grid.size(), (0, 0));
+        assert_eq!(grid.order, Order::RowMajor);
+        assert_eq!(grid.rows(), 0);
+        assert_eq!(grid.cols(), 0);
+        assert_eq!(grid.into_vec(), vec![]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1581,7 +1581,8 @@ impl<T> Grid<T> {
 
 impl<T: Default> Grid<T> {
     /// Expands the grid with the given amount of rows filling the new rows with T::default().
-    ///
+    /// If the grid has no rows or no columns, nothing will happen.
+    /// 
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Hi, I added methods to allow the grid to be expanded by x rows or x cols without the need do a lot of push_rows or push_cols. I don't know if it is a problem, but as I needed to initialize some data to those new rows or cols, i implemented this only for type T that haves the trait Default.

I believe that the benefits of this methods are to make it easier to someone using the lib to expand the grid and also to allow the grid to be expanded with less reallocations of it internal data Vec.

This is my very first contribution to an open source project so if there anything that should be improved, please, feel free to say.