### PR TITLE
feat: add prepend_rows and prepend_cols

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -201,6 +201,60 @@ fn criterion_benchmark(c: &mut Criterion) {
             criterion::BatchSize::SmallInput,
         )
     });
+
+    // Insert
+    c.bench_function("grid_insert_row", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.insert_row(rand(), vec![42; g.cols()]),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("grid_insert_col", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.insert_col(rand(), vec![42; g.rows()]),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // Expand
+    c.bench_function("grid_expand_rows", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.expand_rows(1),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("grid_expand_cols", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.expand_cols(1),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // Prepend
+    c.bench_function("grid_prepend_rows", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.prepend_rows(1),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("grid_prepend_cols", |b| {
+        let grid = init_grid();
+        b.iter_batched(
+            || grid.clone(),
+            |mut g| g.prepend_cols(1),
+            criterion::BatchSize::SmallInput,
+        )
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1725,19 +1725,14 @@ impl<T: Default> Grid<T> {
             self.data
                 .resize_with(self.data.len() + rows * self.cols, T::default);
 
-            match self.order  {
+            match self.order {
                 Order::RowMajor => {
-                    //for i in (0..self.cols).rev() {
-                    //    let s = i * self.rows;
-                    //    let e = (i + cols + 1) * self.rows;
-                    //    self.data[s..e].rotate_left(cols);
-                    //}
                     for i in (0..self.rows).rev() {
                         let s = i * self.cols;
                         let e = (i + rows + 1) * self.cols;
                         self.data[s..e].rotate_left(self.cols);
                     }
-                },
+                }
                 Order::ColumnMajor => {
                     for row_added in 0..rows {
                         for i in (0..self.cols).rev() {
@@ -1776,7 +1771,7 @@ impl<T: Default> Grid<T> {
             self.data
                 .resize_with(self.data.len() + cols * self.rows, T::default);
 
-            match self.order  {
+            match self.order {
                 Order::RowMajor => {
                     for col_added in 0..cols {
                         for i in (0..self.rows).rev() {
@@ -1785,7 +1780,7 @@ impl<T: Default> Grid<T> {
                             self.data[row_idx..=row_idx + total_cols + i].rotate_right(i + 1);
                         }
                     }
-                },
+                }
                 Order::ColumnMajor => {
                     for i in (0..self.cols).rev() {
                         let s = i * self.rows;


### PR DESCRIPTION
Building on #64, I added functionality to expand grids in the other direction.

Should probably rename either these or the expand_* functions as they don't match now.
I like prepend / append as they convey directionality, but they also kind of imply insertion of data rather than just resizing.
Alternatively something like expand_rows_before could work.
Thoughts?